### PR TITLE
Add zip and unzip Packages to Flashcast

### DIFF
--- a/package/Config.in
+++ b/package/Config.in
@@ -13,7 +13,9 @@ endif
 source "package/infozip/Config.in"
 source "package/lzop/Config.in"
 source "package/lzma/Config.in"
+source "package/unzip/Config.in"
 source "package/xz/Config.in"
+source "package/zip/Config.in"
 endmenu
 
 menu "Debugging, profiling and benchmark"

--- a/package/unzip/Config.in
+++ b/package/unzip/Config.in
@@ -1,0 +1,13 @@
+config BR2_PACKAGE_UNZIP
+	bool "unzip"
+	select BR2_PACKAGE_BZIP2
+	help
+	  unzip is a decompression and file packaging utility for Unix,
+	  VMS, MSDOS, OS/2, Windows 9x/NT/XP, Minix, Atari, Macintosh,
+	  MVS, z/OS, Amiga, Acorn RISC, and other OS.
+	  It is analogous to a combination of the Unix commands tar(1)
+	  and compress(1) (or tar(1) and gzip(1)) and is compatible
+	  with PKZIP (Phil Katz's ZIP for MSDOS systems) and other
+	  major zip utilities.
+	  
+	  http://www.info-zip.org/

--- a/package/unzip/unzip.mk
+++ b/package/unzip/unzip.mk
@@ -1,0 +1,20 @@
+#############################################################
+#
+# unzip
+#
+#############################################################
+
+UNZIP_VERSION = 60
+UNZIP_SOURCE = unzip$(UNZIP_VERSION).tar.gz
+UNZIP_SITE = hivelocity.dl.sourceforge.net/infozip/UnZip%206.x%20%28latest%29/UnZip%206.0
+UNZIP_DEPENDENCIES = bzip2
+
+define UNZIP_BUILD_CMDS
+  $(TARGET_MAKE_ENV) $(MAKE) CC="$(TARGET_CC_NOCCACHE)" CPP=$(TARGET_CROSS)cpp RANLIB="$(TARGET_RANLIB)" AR="$(TARGET_AR)" STRIP="$(TARGET_STRIP)" -C $(@D) -f unix/Makefile generic
+endef
+
+define UNZIP_INSTALL_TARGET_CMDS
+  $(INSTALL) -D -m 0755 $(@D)/unzip $(TARGET_DIR)/usr/sbin
+endef
+
+$(eval $(generic-package))

--- a/package/zip/Config.in
+++ b/package/zip/Config.in
@@ -1,0 +1,13 @@
+config BR2_PACKAGE_ZIP
+	bool "zip"
+	select BR2_PACKAGE_BZIP2
+	help
+	  zip is a compression and file packaging utility for Unix,
+	  VMS, MSDOS, OS/2, Windows 9x/NT/XP, Minix, Atari, Macintosh,
+	  MVS, z/OS, Amiga, Acorn RISC, and other OS.
+	  It is analogous to a combination of the Unix commands tar(1)
+	  and compress(1) (or tar(1) and gzip(1)) and is compatible
+	  with PKZIP (Phil Katz's ZIP for MSDOS systems) and other
+	  major zip utilities.
+	  
+	  http://www.info-zip.org/pub/infozip/

--- a/package/zip/zip.mk
+++ b/package/zip/zip.mk
@@ -1,0 +1,20 @@
+#############################################################
+#
+# zip
+#
+#############################################################
+
+ZIP_VERSION = 30
+ZIP_SOURCE = zip$(ZIP_VERSION).tar.gz
+ZIP_SITE = hivelocity.dl.sourceforge.net/infozip/Zip%203.x%20%28latest%29/3.0
+ZIP_DEPENDENCIES = bzip2
+
+define ZIP_BUILD_CMDS
+  $(TARGET_MAKE_ENV) $(MAKE) CC="$(TARGET_CC_NOCCACHE)" CPP=$(TARGET_CROSS)cpp RANLIB="$(TARGET_RANLIB)" AR="$(TARGET_AR)" STRIP="$(TARGET_STRIP)" -C $(@D) -f unix/Makefile generic
+endef
+
+define ZIP_INSTALL_TARGET_CMDS
+  $(INSTALL) -D -m 0755 $(@D)/zip $(TARGET_DIR)/usr/sbin
+endef
+
+$(eval $(generic-package))


### PR DESCRIPTION
This adds the zip and unzip packages from info-zip.org which support symlinks, user permissions, and other features that the busybox package does not.

These packages are required for the upcoming backup and restore features of Flashcast.
